### PR TITLE
Voting Privacy

### DIFF
--- a/app/css/app.css
+++ b/app/css/app.css
@@ -270,3 +270,10 @@ body {
 h1.header__text {
   display: inline-block;
 }
+
+.admin-indicator {
+  vertical-align: text-bottom;
+  line-height: 1.555rem;
+  font-size: 1rem;
+  display: inline-block;
+}

--- a/app/js/controllers.js
+++ b/app/js/controllers.js
@@ -226,7 +226,6 @@ function RoomCtrl($scope, $routeParams, $timeout, socket) {
     }
 
     $scope.connections = roomObj.connections;
-    console.log( roomObj );
     $scope.humanCount = $scope.connections.length;
     $scope.cardPack = roomObj.cardPack;
     $scope.forcedReveal = roomObj.forcedReveal;

--- a/app/partials/room.html
+++ b/app/partials/room.html
@@ -34,13 +34,28 @@
   </div>
   <section class="votePanel" >
     <div class="cards{{votingState}}" id="chosenCards">
-      <div title="{{connection.name}}" ng-repeat="connection in connections track by $index" ng-hide="connection.vote == null" ng-click="unvote(connection.vote.sessionId)" class="card card--2-sided vote btn btn--tertiary btn--small" selectedvote style="color: {{connection.color}}; border-color: {{connection.color}};">
+      <div
+        title="{{(connection.forcedReveal || connection.votes.length === connection.voterCount) ? '' : connection.name}}"
+        ng-repeat="connection in connections track by $index"
+        ng-hide="! connection.voter || (connection.vote == null)"
+        ng-click="unvote(connection.vote.sessionId)"
+        class="card card--2-sided vote btn btn--tertiary btn--small"
+        selectedvote
+        style="color: {{ votingState ? 'inherit' : connection.color}}; border-color: {{votingState ? 'inherit' : connection.color}};"
+      >
         <div class="card--side-1">&#10003;</div>
         <div class="card--side-2">{{connection.vote}}</div>
-        <div class="card--name">{{connection.name}}</div>
+        <div class="card--name">{{votingState ? 'Mystery voter' : connection.name}}</div>
       </div>
 
-      <div title="{{connection.name}}" ng-repeat="connection in connections track by $index" ng-hide="! connection.voter || (connection.vote != null)" class="card card--2-sided vote btn btn--tertiary btn--small" disabled style="color: {{connection.color}}; border-color: {{connection.color}};">
+      <div
+        title="{{(connection.forcedReveal || connection.votes.length === connection.voterCount) ? '' : connection.name}}"
+        ng-repeat="connection in connections track by $index"
+        ng-hide="! connection.voter || (connection.vote != null)"
+        class="card card--2-sided vote btn btn--tertiary btn--small"
+        disabled
+        style="color: {{connection.color}}; border-color: {{connection.color}};"
+      >
         <div class="card--side-1">?</div>
         <div class="card--side-2">?</div>
         <div class="card--name">{{connection.name}}</div>

--- a/app/partials/room.html
+++ b/app/partials/room.html
@@ -1,9 +1,9 @@
 <div ng-init="configureRoom()">
   <div class="switch">
     <label class="label" ng-disabled="forceRevealDisable" data-on="You are a voter" data-off="You are not a voter" for="voter">
-      <input type="checkbox" ng-model="voter" ng-disabled="forceRevealDisable" ng-change="toggleVoter()" id="voter" >
-      <span ng-show="voter">I am voting</span>
-      <span ng-show="!voter">Spectating</span>
+      <input type="checkbox" ng-model="voter" ng-disabled="forceRevealDisable" ng-change="toggleVoter()" id="voter"title="You can toggle voting/spectating while voting is in progress.">
+      <span ng-show="voter" title="You can toggle voting/spectating while voting is in progress.">I am voting</span>
+      <span ng-show="!voter" title="You can toggle voting/spectating while voting is in progress.">Spectating</span>
     </label>
     <button ng-click="resetVote()" class="btn btn--small" title="Start a new vote">
       Reset

--- a/app/partials/room.html
+++ b/app/partials/room.html
@@ -53,7 +53,7 @@
     <div class="cardPanel-meta">
       <div ng-show="voter">
         <div ng-switch on="voted">
-          <p ng-switch-when="false">Hello <strong style="color: {{myColor}}">{{myName}}</strong>, choose your estimate...</p>
+          <p ng-switch-when="false">Hello <strong style="color: {{myColor}}">{{myName}}</strong>, please choose your estimate...</p>
           <p ng-switch-when="true">Hello <strong style="color: {{myColor}}">{{myName}}</strong>, your current estimate is <strong style="color: {{myColor}}">{{myVote}}</strong>.</p>
         </div>
       </div>

--- a/app/partials/room.html
+++ b/app/partials/room.html
@@ -28,6 +28,7 @@
             <li class="dropdown__item"><a href="#" ng-model="cardPack" id="deckCustom" ng-click="setCustomPack()">Custom</a></li>
           </ul>
         </div>
+        <strong class="admin-indicator" ng-switch on="showAdmin">⚡️ You Are The Room Admin</strong>
       </div>
     </div>
   </div>

--- a/server/room.js
+++ b/server/room.js
@@ -167,11 +167,14 @@ Room.prototype.enter = function(socket, data) {
 }
 
 Room.prototype.leave = function(socket) {
-  var connection = _.find(this.connections, function(c) {
+  let connection = _.find(this.connections, (c) => {
     if ( ! c ) {
       return false;
     }
-    return (c.socketIds.length > 0);
+    if (c.socketIds.length == 0) {
+      return false;
+    }
+    return c.socketIds.includes( socket.id );
   });
   if (connection && connection.sessionId) {
     console.log( 'eliminating socket with ID: ' + socket.id, JSON.stringify( this.connections[connection.sessionId].socketIds ) );

--- a/server/server.js
+++ b/server/server.js
@@ -138,7 +138,6 @@ io.sockets.on('connection', function (socket) {
 
   socket.on('reset vote', function (data, callback) {
     statsSocketMessagesReceived++;
-    // console.log("on reset vote  received for " + data.id, socket.id, data);
     var room = lobby.getRoom(data.id);
     if (room.error) {
       callback( { error: room.error });
@@ -161,7 +160,6 @@ io.sockets.on('connection', function (socket) {
 
   socket.on('toggle voter', function (data, callback) {
     statsSocketMessagesReceived++;
-    // console.log("on toggle voter for " + data.id, socket.id, data);
     var room = lobby.getRoom(data.id);
     if (room.error) {
       callback( { error: room.error });


### PR DESCRIPTION
Some minor tweaks, and removes colours/names from the voting cards when votes are revealed to keep voters anonymous:

Before:

<img width="269" alt="Screenshot 2024-03-11 at 23 19 27" src="https://github.com/humanmade/Hatjitsu/assets/58855/50857981-3c86-40cd-ab08-aeffb9c2ea31">

After:

<img width="269" alt="Screenshot 2024-03-11 at 23 19 32" src="https://github.com/humanmade/Hatjitsu/assets/58855/dec67380-0791-42c7-8d43-7ccbc30f11c0">

Another important change was to the `ng-hide` to better hide spectators during voting and results