### PR TITLE
New voting round prompt

### DIFF
--- a/app/css/app.css
+++ b/app/css/app.css
@@ -277,3 +277,10 @@ h1.header__text {
   font-size: 1rem;
   display: inline-block;
 }
+
+.post-vote-controls {
+  display: flex;
+  justify-content: center;
+  flex-direction: row;
+}
+

--- a/app/css/app.css
+++ b/app/css/app.css
@@ -250,6 +250,25 @@ body {
   margin-bottom: 0.5em;
 }
 
+@media screen and (max-width: 30rem) {
+  .header {
+    margin: 0.25rem 0;
+  }
+
+  .header .header__text {
+    font-size: 1.8rem;
+    line-height: 3.3325rem;
+  }
+}
+
+
+@media screen and (max-width: 25rem) {
+  .header .header__text {
+    font-size: 1.6rem;
+    line-height: 3.3325rem;
+  }
+}
+
 .switch {
   margin: 1.66667rem 0;
 }

--- a/app/css/app.css
+++ b/app/css/app.css
@@ -273,6 +273,7 @@ h1.header__text {
 
 .admin-indicator {
   vertical-align: text-bottom;
+  color: darkgoldenrod;
   line-height: 1.555rem;
   font-size: 1rem;
   display: inline-block;

--- a/app/partials/room.html
+++ b/app/partials/room.html
@@ -78,7 +78,7 @@
           <p ng-switch-when="true">Hello <strong style="color: {{myColor}}">{{myName}}</strong>.</p>
         </div>
       </div>
-      <p ng-hide="voter">Hello <strong>spectator</strong>, you have chosen not to vote.</p>
+      <p ng-hide="voter">Hello <strong>spectator <span style="color: {{myColor}}">{{myName}}</span></strong>, you have chosen not to vote.</p>
     </div>
 
     <div ng-switch on="showCustom">

--- a/app/partials/room.html
+++ b/app/partials/room.html
@@ -83,7 +83,7 @@
 
     <div ng-switch on="showCustom">
       <div ng-switch-when="true">
-        <section class="cardPanel" >
+        <section class="cardPanel" ng-show="voter">
           <div class="cards{{cardsState}}">
             <input ng-model="customPack" ui-enter="setCardPack(customPack)" name="packfield" id="packfield" type="tel" maxlength="50" placeholder="comma separated values" class="form__field" autofocus/>
             <button ng-click="setCardPack(customPack)" class="btn">Set Custom Pack</button>
@@ -91,9 +91,9 @@
         </section>
       </div>
       <div ng-switch-when="false">
-        <section class="cardPanel" >
+        <section class="cardPanel" ng-show="voter">
           <div class="cards{{cardsState}}">
-            <div ng-show="cards" ng-repeat="card in cards track by $index" ng-disabled="!voter" ng-click="vote(card)" class="card btn btn--tertiary btn--small" ng-class="{'card--selected' : card==myVote}" cardvalue>
+            <div ng-show="cards" ng-repeat="card in cards track by $index" ng-disabled="!voter || forceRevealDisable" ng-click="vote(card)" class="card btn btn--tertiary btn--small" ng-class="{'card--selected' : card==myVote}" cardvalue>
               {{card}}
             </div>
             <div ng-hide="cards" class="waiting">

--- a/app/partials/room.html
+++ b/app/partials/room.html
@@ -1,6 +1,6 @@
 <div ng-init="configureRoom()">
   <div class="switch">
-    <label class="label" ng-disabled="forceRevealDisable" data-on="You are a voter" data-off="You are not a voter" for="voter">
+    <label class="label" ng-disabled="forceRevealDisable" data-on="You are a voter" data-off="You are a spectator" for="voter">
       <input type="checkbox" ng-model="voter" ng-disabled="forceRevealDisable" ng-change="toggleVoter()" id="voter"title="You can toggle voting/spectating while voting is in progress.">
       <span ng-show="voter" title="You can toggle voting/spectating while voting is in progress.">I am voting</span>
       <span ng-show="!voter" title="You can toggle voting/spectating while voting is in progress.">Spectating</span>

--- a/app/partials/room.html
+++ b/app/partials/room.html
@@ -5,32 +5,30 @@
       <span ng-show="voter" title="You can toggle voting/spectating while voting is in progress.">I am voting</span>
       <span ng-show="!voter" title="You can toggle voting/spectating while voting is in progress.">Spectating</span>
     </label>
-    <button ng-click="resetVote()" class="btn btn--small" title="Start a new vote">
-      Reset
-    </button>
-    <div ng-switch on="showAdmin">
-      <div ng-switch-when="true">
-        <button ng-click="forceReveal()" class="btn btn--small" ng-disabled="forceRevealDisable" title="Force a reveal of all cards if there are some stragglers" >
-          Reveal
-        </button>
-        <div id="dd" class="{{dropdownClass}} dropdown-wrapper btn btn--tertiary btn--small" ng-click="openDropdown()">
-          <span>{{cardPack}} pack</span> <i class="icon icon--arrow-down icon--default" title="icon icon--arrow-down icon--default">arrow-down</i>
-          <ul class="dropdown">
-            <li class="dropdown__item"><a href="#" ng-model="cardPack" id="deckSet135" ng-click="setCardPack('135 set')">135 set</a></li>
-            <li class="dropdown__item"><a href="#" ng-model="cardPack" id="deckGoat" ng-click="setCardPack('Mountain Goat')">Mountain Goat</a></li>
-            <li class="dropdown__item"><a href="#" ng-model="cardPack" id="deckFib" ng-click="setCardPack('Fibonacci')">Fibonacci</a></li>
-            <li class="dropdown__item"><a href="#" ng-model="cardPack" id="deckSeq" ng-click="setCardPack('Sequential')">Sequential</a></li>
-            <li class="dropdown__item"><a href="#" ng-model="cardPack" id="deckPlay" ng-click="setCardPack('Playing Cards')">Playing Cards</a></li>
-            <li class="dropdown__item"><a href="#" ng-model="cardPack" id="deckShirt" ng-click="setCardPack('T-Shirt')">T-Shirt</a></li>
-            <li class="dropdown__item"><a href="#" ng-model="cardPack" id="deck1-5" ng-click="setCardPack('1-5')">1 to 5</a></li>
-            <li class="dropdown__item"><a href="#" ng-model="cardPack" id="deck1-10" ng-click="setCardPack('1-10')">1 to 10</a></li>
-            <li class="dropdown__item"><a href="#" ng-model="cardPack" id="deckShirt" ng-click="setCardPack('Fruit')">Fruit</a></li>
-            <li class="dropdown__item"><a href="#" ng-model="cardPack" id="deckCustom" ng-click="setCustomPack()">Custom</a></li>
-          </ul>
-        </div>
-        <strong class="admin-indicator" ng-switch on="showAdmin">⚡️ You Are The Room Admin</strong>
+
+      <button ng-show="showAdmin" ng-click="resetVote()" class="btn btn--small" ng-disabled="forceRevealDisable" title="Start a new vote">
+        Reset
+      </button>
+      <button ng-show="showAdmin" ng-click="forceReveal()" class="btn btn--small" ng-disabled="forceRevealDisable" title="Force a reveal of all cards if there are some stragglers" >
+        Reveal
+      </button>
+      <div ng-show="showAdmin" id="dd" class="{{dropdownClass}} dropdown-wrapper btn btn--tertiary btn--small" ng-click="openDropdown()">
+        <span>{{cardPack}} pack</span> <i class="icon icon--arrow-down icon--default" title="icon icon--arrow-down icon--default">arrow-down</i>
+        <ul class="dropdown">
+          <li class="dropdown__item"><a href="#" ng-model="cardPack" id="deckSet135" ng-click="setCardPack('135 set')">135 set</a></li>
+          <li class="dropdown__item"><a href="#" ng-model="cardPack" id="deckGoat" ng-click="setCardPack('Mountain Goat')">Mountain Goat</a></li>
+          <li class="dropdown__item"><a href="#" ng-model="cardPack" id="deckFib" ng-click="setCardPack('Fibonacci')">Fibonacci</a></li>
+          <li class="dropdown__item"><a href="#" ng-model="cardPack" id="deckSeq" ng-click="setCardPack('Sequential')">Sequential</a></li>
+          <li class="dropdown__item"><a href="#" ng-model="cardPack" id="deckPlay" ng-click="setCardPack('Playing Cards')">Playing Cards</a></li>
+          <li class="dropdown__item"><a href="#" ng-model="cardPack" id="deckShirt" ng-click="setCardPack('T-Shirt')">T-Shirt</a></li>
+          <li class="dropdown__item"><a href="#" ng-model="cardPack" id="deck1-5" ng-click="setCardPack('1-5')">1 to 5</a></li>
+          <li class="dropdown__item"><a href="#" ng-model="cardPack" id="deck1-10" ng-click="setCardPack('1-10')">1 to 10</a></li>
+          <li class="dropdown__item"><a href="#" ng-model="cardPack" id="deckShirt" ng-click="setCardPack('Fruit')">Fruit</a></li>
+          <li class="dropdown__item"><a href="#" ng-model="cardPack" id="deckCustom" ng-click="setCustomPack()">Custom</a></li>
+        </ul>
       </div>
-    </div>
+      <strong ng-show="showAdmin" class="admin-indicator" ng-switch on="showAdmin">⚡️ Room Admin</strong>
+
   </div>
   <section class="votePanel" >
     <div class="cards{{votingState}}" id="chosenCards">

--- a/app/partials/room.html
+++ b/app/partials/room.html
@@ -61,6 +61,14 @@
         <div class="card--name">{{connection.name}}</div>
       </div>
     </div>
+    <div
+      class="post-vote-controls"
+      ng-show="forceRevealDisable"
+    >
+      <button ng-click="resetVote()" class="btn btn--small" title="Start a new vote">
+        Start New Vote
+      </button>
+    </div>
 
   </section>
 

--- a/app/partials/room.html
+++ b/app/partials/room.html
@@ -75,7 +75,7 @@
       <div ng-show="voter">
         <div ng-switch on="voted">
           <p ng-switch-when="false">Hello <strong style="color: {{myColor}}">{{myName}}</strong>, please choose your estimate...</p>
-          <p ng-switch-when="true">Hello <strong style="color: {{myColor}}">{{myName}}</strong>, your current estimate is <strong style="color: {{myColor}}">{{myVote}}</strong>.</p>
+          <p ng-switch-when="true">Hello <strong style="color: {{myColor}}">{{myName}}</strong>.</p>
         </div>
       </div>
       <p ng-hide="voter">Hello <strong>spectator</strong>, you have chosen not to vote.</p>

--- a/server/room.js
+++ b/server/room.js
@@ -227,7 +227,9 @@ Room.prototype.destroyVote = function(socket, data) {
 
 Room.prototype.resetVote = function() {
   _.forEach(this.connections, function(c) {
-    c.vote = null;
+    if ( c ) {
+      c.vote = null;
+    }
   })
   this.forcedReveal = false;
   this.io.sockets.in(this.id).emit('vote reset');


### PR DESCRIPTION
Admin controls have been adjusted to not show the reset button to everyone and instead prompt to start a new note:

<img width="988" alt="Screenshot 2024-03-12 at 11 53 56" src="https://github.com/humanmade/Hatjitsu/assets/58855/101359d5-5871-436d-947b-e8b0bdd0ce94">


Mobile header improvements:

Before:

<img width="449" alt="Screenshot 2024-03-12 at 16 17 34" src="https://github.com/humanmade/Hatjitsu/assets/58855/3d25ff92-383b-4384-93ef-fc77257d0c31">


After:

<img width="449" alt="Screenshot 2024-03-12 at 16 17 10" src="https://github.com/humanmade/Hatjitsu/assets/58855/a69c7db4-bd03-4cdd-87ae-e46e16c031a8">

Also:

 - hides voting cards for spectators
 - spectators now have their name shown
 - voting cards are disabled and faded out when results are shown