### PR TITLE
Toasts

### DIFF
--- a/app/css/app.css
+++ b/app/css/app.css
@@ -170,57 +170,36 @@ body {
 }
 
 /*
-
   Alerts
-
 */
 .alert {
   z-index: 3;
-  top: 0;
+  bottom: 0;
   left: 0;
-  width: 100%;
+  max-width: 300px;
   position: fixed;
+  display: flex;
+  flex-direction: column-reverse;
 }
-@media screen and (min-width: 55em) {
-  .alert {
-    position: absolute;
-  }
-}
-.alert .activity {
-  margin-top: 0.2em;
-  margin-bottom: 0.2em;
-  margin-right: 0.2em;
-  float: right;
-  text-align: right;
-}
-.socketMessage,
-.appError,
-.message {
+
+.notification {
   padding: 0 2em 0 0.5em;
   line-height: 1.5em;
-  margin: 1em;
-  padding: 1em 2em;
+  margin: 0.25em;
+  padding: 0.5em 1em;
   max-width: 100%;
   border-radius: 4px;
-  color: rgba(0,0,0,.7);
-}
-
-.socketMessage:empty,
-.appError:empty,
-.message:empty {
-  display: none;
-}
-
-.message {
-  background-color: #ffdd57;
-}
-.socketMessage {
+  font-size: 0.9em;
   background-color: black;
   color: #fff;
 }
-.appError {
+
+.notification:empty {
+  display: none;
+}
+
+.notification.appError {
   background-color: #f14668;
-  color: #fff;
 }
 /*
 

--- a/app/index.ejs
+++ b/app/index.ejs
@@ -50,10 +50,10 @@
         </header>
 
         <div class="alert">
-          <div class="activity" ng-show="activity"><span class="loading--red loading--active"></span></div>
-          <div class="socketMessage" class="notification" ng-show="socketMessage" ng-bind="socketMessage"></div>
-          <div class="appError" class="notification" ng-show="errorMessage" ng-bind="errorMessage"></div>
-          <div class="message" class="notification" ng-show="message" ng-bind="message"></div>
+          <div class="activity notification" ng-show="activity"><span class="loading--white loading--active"></span></div>
+          <div class="socketMessage notification" ng-show="socketMessage" ng-bind="socketMessage"></div>
+          <div class="appError notification" ng-show="errorMessage" ng-bind="errorMessage"></div>
+          <div class="message notification" ng-show="message" ng-bind="message"></div>
         </div>
 
         <div class="content" ng-view></div>


### PR DESCRIPTION
With this change alerts now appear as toasts in the bottom left corner of the screen instead of giant full width banners at the top:

<img width="217" alt="Screenshot 2024-03-12 at 21 17 07" src="https://github.com/humanmade/Hatjitsu/assets/58855/9d8dc344-6119-42f7-85e6-fa8df9f68fae">

Also fixed some HTML issues around the alerts